### PR TITLE
Fixed a bug that froze plugins on single core nodes

### DIFF
--- a/polus-precompute-slide-plugin/src/main.py
+++ b/polus-precompute-slide-plugin/src/main.py
@@ -41,7 +41,7 @@ def main():
     # Each pyramid is built within its own process, with a maximum number of processes
     # equal to number of cpus - 1.
     for image in images:
-        if len(processes) >= multiprocessing.cpu_count()-1:
+        if len(processes) >= multiprocessing.cpu_count()-1 and len(processes)>0:
             free_process = -1
             while free_process<0:
                 for process in range(len(processes)):

--- a/polus-stack-z-slice-plugin/src/main.py
+++ b/polus-stack-z-slice-plugin/src/main.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
                         ys.sort() # sorted list of y-positions
                         for y in ys:
                             # If there are num_cores - 1 processes running, wait until one finishes
-                            if len(processes) >= multiprocessing.cpu_count()-1:
+                            if len(processes) >= multiprocessing.cpu_count()-1 and len(processes) > 0:
                                 free_process = -1
                                 while free_process<0:
                                     for process in range(len(processes)):
@@ -98,7 +98,7 @@ if __name__ == "__main__":
                     ps.sort()
                     for p in ps:
                         # If there are num_cores - 1 processes running, wait until one finishes
-                        if len(processes) >= multiprocessing.cpu_count()-1:
+                        if len(processes) >= multiprocessing.cpu_count()-1 and len(processes) > 0:
                             free_process = -1
                             while free_process<0:
                                 for process in range(len(processes)):


### PR DESCRIPTION
Some plugins use boilerplate code that spawns processes based on how data is divided by a filename pattern. The code only permits `n-1` active processes, where `n` is the number of cores on the machine/node. There was no logic to check for a single core, so the code would only permit 0 active processes to run (which effectively launches no processes). This PR fixes that issue by making sure at least one process can be started if there are no other processes running.