### PR TITLE
Added new bfio container with Tensorflow 2.1.0

### DIFF
--- a/utils/polus-bfio-util/README.md
+++ b/utils/polus-bfio-util/README.md
@@ -4,3 +4,26 @@ This tool is a simplified but powerful interface to the [Bioformats java library
 
 This tool is currently not on any public pip repositories, but can be installed by cloning this repository and installing with pip.
 
+## Universal Container Components
+
+All containers contain the follow components:
+1. Python 3.6
+2. openjdk-8
+3. numpy (version 1.18.1)
+4. javabridge (version 1.0.18)
+5. python-bioformats (version 1.5.2)
+6. bfio (version 1.0.8)
+
+## Containers
+
+### labshare/polus-bfio-util:1.0.8 & labshare/polus-bfio-util:1.0.8-alpine
+
+This container is built on Alpine Linux. This is the smallest bfio container, but also the most difficult to install additional requirements on.
+
+### labshare/polus-bfio-util:1.0.8-slim-buster
+
+This container is built on a stripped down version of Debian Buster. This container is larger than the `alpine` version, but easier to install new Python packages on.
+
+### labshare/polus-bfio-util:1.0.8-tensorflow
+
+This container is built on Debian Buster and includes Tensorflow 2.1.0 and all necessary GPU drivers to run Tensorflow on an NVIDIA graphics card.

--- a/utils/polus-bfio-util/build-docker.sh
+++ b/utils/polus-bfio-util/build-docker.sh
@@ -3,3 +3,4 @@
 version=$(<VERSION)
 docker build . -f ./slim-buster/Dockerfile -t labshare/polus-bfio-util:${version}-slim-buster
 docker build . -f ./alpine/Dockerfile -t labshare/polus-bfio-util:${version}-alpine -t labshare/polus-bfio-util:${version}
+docker build . -f ./tensorflow/Dockerfile -t labshare/polus-bfio-util:${version}-tensorflow

--- a/utils/polus-bfio-util/tensorflow/Dockerfile
+++ b/utils/polus-bfio-util/tensorflow/Dockerfile
@@ -1,0 +1,28 @@
+### 1. Get Linux
+FROM tensorflow/tensorflow:2.1.0-gpu-py3
+
+# Install open JDK 8
+RUN apt-get update && \
+    apt-get -y install openjdk-8-jdk
+
+RUN apt-get update && \    
+    pip3 install --upgrade pip --no-cache-dir
+
+# Create temporary folder
+ARG EXEC_DIR="/opt/executables"
+RUN mkdir -p ${EXEC_DIR}
+
+# Copy bfio
+COPY . ${EXEC_DIR}/
+
+# Install bfio and requirements
+RUN apt-get update && \        
+    pip3 install --upgrade cython && \
+    pip3 install -r  ${EXEC_DIR}/requirements.txt --no-cache-dir && \
+    pip3 install ${EXEC_DIR}/ --no-cache-dir && \
+    mv ${EXEC_DIR}/bfio/jars/loci_tools.jar /usr/local/lib/python3.6/dist-packages/bioformats/jars/loci_tools.jar -f && \
+    rm -rf ${EXEC_DIR}
+
+ARG DATA_DIR="/data"
+
+WORKDIR ${EXEC_DIR}


### PR DESCRIPTION
This commit adds a Dockerfile to build a new container with Tensorflow 2.1.0 and all necessary GPU drivers.

In addition, the README was updated to describe the contents of the 3 different `bfio` containers and the Python packages they come installed with.